### PR TITLE
Update main.yml to have sub navigation for the user guide

### DIFF
--- a/_data/sidebars/main.yml
+++ b/_data/sidebars/main.yml
@@ -9,4 +9,14 @@ subitems:
     url: /main/contributors
   - title: User Guide
     url: /user-guide/
-  
+    subitems:
+      - title: Accessing the service
+        url: /user-guide/service-access
+      - title: Logging in
+        url: /user-guide/loggin
+      - title: Configure and use compute environments
+        url: /user-guide/compute-env
+      - title: Adding workflows
+        url: /user-guide/add-workflow
+      - title: Recommendations
+        url: /user-guide/hpc-recommendations


### PR DESCRIPTION
Please double check that I've got the formatting right. It's based on how-to hub https://github.com/AustralianBioCommons/how-to-hub/blob/main/_data/sidebars/main.yml